### PR TITLE
Add payment-pending topic to order status change event handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add payment-pending topic to order status change event handler
+
 ## [0.20.6] - 2022-04-29
 
 ### Changed

--- a/node/service.json
+++ b/node/service.json
@@ -46,7 +46,7 @@
     },
     "updateOrderStatus": {
       "sender": "vtex.orders-broadcast",
-      "topics": ["payment-approved", "cancel"]
+      "topics": ["payment-pending", "payment-approved", "cancel"]
     },
     "updateInvoicedOrder": {
       "sender": "vtex.orders-broadcast",


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Add payment-pending topic to order status change event handler
- 
#### What problem is this solving?

The order status changed events `order-created` and `payment-pending` are triggered really close together, so we were only really using `order-created` before. This change adds a listener to the other event to prevent edge cases and ensure that both are being handled accordingly.

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
