### PR TITLE
add status to spreadsheet of Order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- status to spreadsheet of Orders
+
 ## [0.23.2] - 2022-08-02
 
 ### Fixed

--- a/node/services/ExportMDSheetService.ts
+++ b/node/services/ExportMDSheetService.ts
@@ -48,7 +48,7 @@ export class ExportMDSheetService {
   private formatAffiliateOrders = (page: AffiliatesOrders[]) => {
     const newPage: AffiliateOrderExportingRow[] = []
 
-    page.forEach(({ id, affiliateId, orderTotalCommission, orderItems }) => {
+    page.forEach(({ id, affiliateId, orderTotalCommission, orderItems, status }) => {
       orderItems.forEach(({ skuId, skuName, price, quantity, commission }) => {
         newPage.push({
           id: `${id}`,
@@ -59,6 +59,7 @@ export class ExportMDSheetService {
           price,
           quantity,
           commission,
+          status,
         })
       })
     })

--- a/node/utils/exporting.ts
+++ b/node/utils/exporting.ts
@@ -8,7 +8,8 @@ export type AffiliateOrderExportingRow = {
   skuName: string
   price: number
   quantity: number
-  commission: number
+  commission: number,
+  status: string | undefined,
 }
 
 export const bucketNameForExporting = (type: MDEntityForExporting) =>
@@ -16,7 +17,7 @@ export const bucketNameForExporting = (type: MDEntityForExporting) =>
 
 export const fieldsForExporting = (type: MDEntityForExporting) =>
   type === 'affiliatesOrders'
-    ? ['id', 'affiliateId', 'orderTotalCommission', 'orderItems']
+    ? ['id', 'affiliateId', 'orderTotalCommission', 'orderItems', 'status']
     : ['id', 'commission']
 
 export const PAGE_SIZE_FOR_EXPORTING = 1000


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add status of order to the Order spreadsheet

#### What problem is this solving?

Honey be detected some bugs in the order control admin interface that are making it difficult to control commissions.

#### How to test it?

[<!--- Don't forget to add a link to a Workspace where this branch is linked -->
]()
[Workspace](https://bibiplan--honeybe.myvtex.com/admin/affiliates-dashboard)

#### Screenshots or example usage

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

![image](https://user-images.githubusercontent.com/67066494/183075806-ab79c214-115a-44b8-9bc7-2f4dfbeb594a.png)


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/wxgimHAKx2xA4/giphy.gif)

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
