### PR TITLE
Feature / VBase and graphQL operations added

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -16,6 +16,7 @@ type Query {
   ): CommissionsBySKUPage
 
   lastImportedCommissionFileInfo: ImportedCommissionsFileInfo
+  getNotFoundCommissions: Boolean
 }
 
 type Mutation {
@@ -33,6 +34,7 @@ type Mutation {
   ): Boolean
 
   importCommissionsBySKU(file: Upload!): Boolean
+  deleteNotFounds: Boolean
 }
 
 scalar File

--- a/manifest.json
+++ b/manifest.json
@@ -41,10 +41,7 @@
       }
     },
     {
-      "name": "vbase-read-write",
-      "attrs": {
-        "bucket": "affiliate_orders"
-      }
+      "name": "vbase-read-write"
     },
     {
       "name": "template-criar"

--- a/node/middlewares/commission/setCommissionEventHandler.ts
+++ b/node/middlewares/commission/setCommissionEventHandler.ts
@@ -12,7 +12,7 @@ export async function setCommissionEventHandler(
       data: { id, commission, refId },
       senderAppId,
     },
-    clients: { commissionBySKU, catalog },
+    clients: { commissionBySKU, catalog, vbase },
   } = ctx
 
   if (senderAppId !== 'vtex.affiliates-commission-service') return
@@ -25,7 +25,9 @@ export async function setCommissionEventHandler(
       refId: refId && String(refId),
     })
   } catch (error) {
-    if (error?.response?.status === HTTP_ERRORS.notFound.status) return
+    if (error?.response?.status === HTTP_ERRORS.notFound.status){
+      vbase.saveJSON('not-found',"notfound", {notFound: id})
+    }
     if (error?.response?.status !== HTTP_ERRORS.noChanges.status) throw error
   }
 

--- a/node/resolvers/commissionsBySKU/index.ts
+++ b/node/resolvers/commissionsBySKU/index.ts
@@ -28,6 +28,17 @@ export const queries = {
     __: unknown,
     { clients: { vbase } }: Context
   ) => vbase.getJSON('last-import', 'info'),
+  getNotFoundCommissions: async(
+    _: unknown,
+    __: unknown,
+    { clients: { vbase } }: Context
+  ) => {
+    const response: {notFound: number | string} = await vbase.getJSON('not-found', 'notfound')
+    if(response?.notFound){
+      return true
+    }
+    return false
+  }
 }
 
 export const mutations = {
@@ -83,6 +94,17 @@ export const mutations = {
 
     return true
   },
+  deleteNotFounds: async(
+    _: unknown,
+    __: unknown,
+    { clients: { vbase } }: Context
+  ) => {
+    await vbase.saveJSON('not-found',"notfound",{})
+    .then(() => {return true})
+    .catch((error) => {
+      throw error
+    })
+  }
 }
 
 export const fieldResolvers = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adding a VBase operation to be activated when a value is not found by the catalog API, it must run on the commissions Middleware.
For the front end to access the VBase information, there were 2 resolvers created as well.

#### What problem is this solving?

SKUs error message

#### How to test it?

Accessing the link below and uploading some spreadsheets
https://commissionstest--bibiafiliados.myvtex.com/admin/affiliates-commissions

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/bq6F8QYqBU7Yc/giphy-downsized.gif)

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
